### PR TITLE
`nvte_cublas_gemm_v2` to take alpha pointer

### DIFF
--- a/transformer_engine/common/gemm/cublaslt_gemm.cu
+++ b/transformer_engine/common/gemm/cublaslt_gemm.cu
@@ -761,7 +761,7 @@ void nvte_cublas_gemm_v2(int transa, int transb, float *alpha, const NVTETensor 
   // Data tensors
   const Tensor *A_tensor = convertNVTETensorCheck(A);
   const Tensor *B_tensor = convertNVTETensorCheck(B);
-  const Tensor *C_tensor = convertNVTETensor(C);
+  const Tensor *C_tensor = convertNVTETensorCheck(C);
   Tensor *D_tensor = convertNVTETensorCheck(D);
   Tensor *workspace_tensor = convertNVTETensor(workspace);
   NVTE_CHECK(C_tensor == D_tensor,

--- a/transformer_engine/common/gemm/cublaslt_gemm.cu
+++ b/transformer_engine/common/gemm/cublaslt_gemm.cu
@@ -327,7 +327,7 @@ void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
 
   // Tensor scaling factors for NVFP4
   if (use_fp4 && inputA->amax.dptr && inputB->amax.dptr) {
-    // Include tensor scales in alpha for NVFP4 GEMMs is amax-s are provided
+    // Include tensor scales in alpha for NVFP4 GEMMs when amaxs are provided
     // Note: Store alpha in user-provided workspace and store beta in the device constant memory.
     NVTE_CHECK(workspaceSize >= 4, "NVFP4 GEMM requires at least 4 byte workspace, but got ",
                workspaceSize, " bytes.");
@@ -338,7 +338,7 @@ void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
     TensorWrapper D_tensor_scale_inv(D_tensor_scale_inv_ptr, std::vector<size_t>{1},
                                      DType::kFloat32);
     // 1. Calculate tensor scale inv for D from the input A.amax and B.amax
-    // 2. Multiply the tensor scale inv with provided alpha
+    // 2. Multiply the tensor scale inv with the provided alpha
     // 3. Write the result back to the D_tensor_scale_inv_ptr
     nvte_nvfp4_compute_per_tensor_scale(inputA->nvte_tensor, transa, inputB->nvte_tensor, !transb,
                                         *alpha_ptr, D_tensor_scale_inv.data(), stream);

--- a/transformer_engine/common/include/transformer_engine/gemm.h
+++ b/transformer_engine/common/include/transformer_engine/gemm.h
@@ -128,8 +128,8 @@ void nvte_cublas_gemm(const NVTETensor A, const NVTETensor B, NVTETensor D, cons
  *  \param[in]  config    Additional configuration.
  *  \param[in]  stream    CUDA stream used for the operation.
  */
-void nvte_cublas_gemm_v2(int transa, int transb, float alpha, const NVTETensor A,
-                         const NVTETensor B, float beta, const NVTETensor C, NVTETensor D,
+void nvte_cublas_gemm_v2(int transa, int transb, float *alpha, const NVTETensor A,
+                         const NVTETensor B, float *beta, const NVTETensor C, NVTETensor D,
                          NVTETensor workspace, NVTEMatmulConfig config, cudaStream_t stream);
 
 /*! \brief Compute matrix multiplication of 2 matrices, potentially fused with other operations,

--- a/transformer_engine/common/include/transformer_engine/gemm.h
+++ b/transformer_engine/common/include/transformer_engine/gemm.h
@@ -128,8 +128,8 @@ void nvte_cublas_gemm(const NVTETensor A, const NVTETensor B, NVTETensor D, cons
  *  \param[in]  config    Additional configuration.
  *  \param[in]  stream    CUDA stream used for the operation.
  */
-void nvte_cublas_gemm_v2(int transa, int transb, float *alpha, const NVTETensor A,
-                         const NVTETensor B, float *beta, const NVTETensor C, NVTETensor D,
+void nvte_cublas_gemm_v2(int transa, int transb, const float *alpha, const NVTETensor A,
+                         const NVTETensor B, const float *beta, const NVTETensor C, NVTETensor D,
                          NVTETensor workspace, NVTEMatmulConfig config, cudaStream_t stream);
 
 /*! \brief Compute matrix multiplication of 2 matrices, potentially fused with other operations,

--- a/transformer_engine/pytorch/csrc/extensions/gemm.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/gemm.cpp
@@ -289,7 +289,7 @@ std::vector<py::object> gemm(py::handle A, bool transa, py::handle B, bool trans
     } else {
       // Launch GEMM
       NVTE_SCOPED_GIL_RELEASE({
-        nvte_cublas_gemm_v2(transa, transb, alpha, A_tensor.data(), B_tensor.data(), *beta,
+        nvte_cublas_gemm_v2(transa, transb, &alpha, A_tensor.data(), B_tensor.data(), &beta.value(),
                             out_tensor.data(), out_tensor.data(), te_workspace.data(), config,
                             main_stream);
       });

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -78,12 +78,8 @@ class UserBufferQuantizationMode(Enum):
 def get_cublas_workspace_size_bytes() -> None:
     """Return 32 MiB if using hopper, 4 MiB for all other architectures."""
     if torch.cuda.get_device_properties(torch.cuda.current_device()).major >= 9:
-        # We need to store GEMM alpha and beta on device for NVFP4 recipe,
-        # which requires 2 additional bytes that are used from the workspace.
-        # To keep workspace 4-byte aligned, add an additional 4 bytes here because
-        # the full amount of 33_554_432 (32 MiB) is required for selecting optimal
-        # GEMM kernel for NVFP4.
-        return 33_554_436
+        # 32 MiB for NVFP4 GEMM, plus 128 B for misc scales
+        return 32 * 1024 * 1024 + 128
     return 4_194_304
 
 

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -78,8 +78,8 @@ class UserBufferQuantizationMode(Enum):
 def get_cublas_workspace_size_bytes() -> None:
     """Return 32 MiB if using hopper, 4 MiB for all other architectures."""
     if torch.cuda.get_device_properties(torch.cuda.current_device()).major >= 9:
-        # 32 MiB for NVFP4 GEMM, plus 128 B for misc scales
-        return 32 * 1024 * 1024 + 128
+        # 32 MiB for NVFP4 GEMM, plus 256 B for misc scales
+        return 32 * 1024 * 1024 + 256
     return 4_194_304
 
 


### PR DESCRIPTION
# Description

This PR changes the API from
```
void nvte_cublas_gemm_v2(int transa, int transb, float alpha, const NVTETensor A,
                         const NVTETensor B, float beta, const NVTETensor C, NVTETensor D,
                         NVTETensor workspace, NVTEMatmulConfig config, cudaStream_t stream);
 ```
 to
 ```
 void nvte_cublas_gemm_v2(int transa, int transb, const float *alpha, const NVTETensor A,
                         const NVTETensor B, const float *beta, const NVTETensor C, NVTETensor D,
                         NVTETensor workspace, NVTEMatmulConfig config, cudaStream_t stream);
 ```
 
 Besides, the tensor scale inv calculation for D is moved to the main `cublas_gemm` function.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
